### PR TITLE
allows windows machines to use `agent controller init`

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,3 +1,19 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
 package agent
 
 import (
@@ -14,7 +30,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -52,7 +67,7 @@ func GetGopsProcesses() ([]*Process, error) {
 			}
 			// process is alive and is reachable by us
 			if process, err := os.FindProcess(pid); err == nil {
-				if err = process.Signal(syscall.Signal(0)); err == nil {
+				if isReachable(process) {
 					proc, err := ps.FindProcess(pid)
 					if err != nil {
 						return nil, err
@@ -84,7 +99,7 @@ func tooManyProcsError(procs []*Process) error {
 		list = append(list, v.String())
 	}
 	builder := &strings.Builder{}
-	builder.WriteString("too many gops-agent process found, including [")
+	builder.WriteString("too many gops-agent process found, specify one, found [")
 	builder.WriteString(strings.Join(list, ", "))
 	builder.WriteString("]")
 	return errors.New(builder.String())

--- a/proc_nowin.go
+++ b/proc_nowin.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package agent
+
+import (
+	"os"
+	"syscall"
+)
+
+func isReachable(proc *os.Process) bool {
+	err := proc.Signal(syscall.Signal(0))
+
+	return err == nil
+}

--- a/proc_windows.go
+++ b/proc_windows.go
@@ -1,0 +1,25 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package agent
+
+import (
+	"os"
+)
+
+func isReachable(proc *os.Process) bool {
+	return true
+}


### PR DESCRIPTION
gops in Windows stores socket files in %TEMP% which is user specific (e.g.C:\Users\user1\AppData\Local\Temp\gops-agent.19372.sock). For windows instead of relying on sig(0) for a ping we assume writability.